### PR TITLE
Wepgcomp 14 alterar fluxo de erros na tela de cadastro

### DIFF
--- a/frontend/src/app/cadastro/page.tsx
+++ b/frontend/src/app/cadastro/page.tsx
@@ -20,27 +20,23 @@ export default function Cadastro() {
     if (signed) {
       router.push("/home");
     }
-  }, []);
+  }, [signed, router]);
 
   return (
-    <div className='container d-flex flex-column flex-grow-1 text-black cadastro'>
+    <div className='container d-flex flex-column flex-grow-1 text-black cadastro position-relative'>
       {loadingCreateUser && <LoadingPage />}
-      {!loadingCreateUser && (
-        <>
-          <div className='container'>
-            <h1 className='d-flex justify-content-center mt-5 fw-normal ms-2'>
-              {Edicao?.name || "Carregando..."}
-            </h1>
-            <hr />
-            <h2 className='d-flex justify-content-center mb-4 fw-bold text-black'>
-              Cadastro
-            </h2>
-          </div>
-          <div className='container d-flex justify-content-center mb-5'>
-            <FormCadastro />
-          </div>
-        </>
-      )}
+      <div className='container'>
+        <h1 className='d-flex justify-content-center mt-5 fw-normal ms-2'>
+          {Edicao?.name || "Carregando..."}
+        </h1>
+        <hr />
+        <h2 className='d-flex justify-content-center mb-4 fw-bold text-black'>
+          Cadastro
+        </h2>
+      </div>
+      <div className='container d-flex justify-content-center mb-5'>
+        <FormCadastro />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Forms/Cadastro/FormCadastro.tsx
+++ b/frontend/src/components/Forms/Cadastro/FormCadastro.tsx
@@ -110,16 +110,6 @@ export function FormCadastro() {
       ouvinte: "Listener",
     };
 
-    if (
-      !nome ||
-      !email ||
-      !senha ||
-      !perfil ||
-      (perfil !== "ouvinte" && !matricula)
-    ) {
-      throw new Error("Campos obrigatórios em branco.");
-    }
-
     if(perfil === profileFormated.doutorando || perfil === profileFormated.professor) {
       if (!email.toLowerCase().endsWith("@ufba.br")) {
         throw new Error("E-mail inválido. Deve ser um e-mail da UFBA.");


### PR DESCRIPTION
Comportamento do useEffect e de como a página era renderizada estava todo errado. Antes, ele desmontava todo o formulário ao receber uma excecao e o estado do formulário todo se perdia. Comportamento foi alterado

Também apaguei um código que era inútil e não executaria, pois o próprio front faz a validação se há campos vazios e não executa a função de submissão.