### PR TITLE
PDF de apresentaçao deve ser obrigatório ao cadastrar apresentação

### DIFF
--- a/frontend/src/components/Forms/CadastroApresentacao/FormCadastroApresentacao.tsx
+++ b/frontend/src/components/Forms/CadastroApresentacao/FormCadastroApresentacao.tsx
@@ -44,7 +44,7 @@ const esquemaCadastro = z.object({
   slide: z
     .string({ invalid_type_error: "Campo Inválido" })
     .refine((val) => val && val.trim().length > 0, {
-        message: "O PDF é obrigatório",
+        message: "O envio do slide em PDF é obrigatório",
       }),
 });
 

--- a/frontend/src/components/Forms/CadastroApresentacao/FormCadastroApresentacao.tsx
+++ b/frontend/src/components/Forms/CadastroApresentacao/FormCadastroApresentacao.tsx
@@ -41,7 +41,11 @@ const esquemaCadastro = z.object({
       const celularFormatado = value.replace(/\D/g, "");
       return celularFormatado.length >= 10 && celularFormatado.length <= 11;
     }, "O celular deve conter 10 ou 11 dígitos"),
-  slide: z.string({ invalid_type_error: "Campo Inválido" }).optional(),
+  slide: z
+    .string({ invalid_type_error: "Campo Inválido" })
+    .refine((val) => val && val.trim().length > 0, {
+        message: "O PDF é obrigatório",
+      }),
 });
 
 type CadastroFormulario = z.infer<typeof esquemaCadastro>;
@@ -122,7 +126,9 @@ export function FormCadastroApresentacao() {
     if (arquivoSelecionado) {
       setArquivo(arquivoSelecionado);
       setNomeArquivo(arquivoSelecionado.name);
-      setValue("slide", arquivoSelecionado.name);
+      setValue("slide", arquivoSelecionado.name, {
+          shouldValidate: true,
+       });
     }
   };
 


### PR DESCRIPTION
Ao cadastrar uma apresentação o arquivo .pdf é obrigatório 
<img width="567" height="264" alt="{A4628551-AD15-4833-AEF9-7DF3257A8703}" src="https://github.com/user-attachments/assets/1c229914-8ef8-45e9-af21-9f55b2769b61" />

