### PR TITLE
Refatorar tela de cadastrar edição

### DIFF
--- a/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
+++ b/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
@@ -35,16 +35,16 @@ const formEdicaoSchema = z.object({
 
   inicio: z
     .string({
-      invalid_type_error: "Data e horário de início são obrigatórios!",
+      invalid_type_error: "Data de início são obrigatórios!",
     })
     .datetime({
-      message: "Data ou horário inválidos!",
+      message: "Data inválida!",
     }),
 
   final: z
-    .string({ invalid_type_error: "Data e horário de fim são obrigatórios!" })
+    .string({ invalid_type_error: "Data de fim são obrigatórios!" })
     .datetime({
-      message: "Data ou horário inválidos!",
+      message: "Data inválida!",
     }),
 
   local: z
@@ -99,9 +99,13 @@ const formEdicaoSchema = z.object({
 
   sessoes: z.number({
     invalid_type_error: "O número de sessões é obrigatório!",
+  }).nonnegative({
+    message: "O número de sessões não pode ser negativo!"
   }),
   duracao: z.number({
     invalid_type_error: "Informar a duração é obrigatório!",
+  }).nonnegative({
+    message: "A duração não pode ser negativa!"
   }),
   submissao: z
     .string({ invalid_type_error: "Campo Inválido" })
@@ -146,9 +150,10 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
     control,
     handleSubmit,
     setValue,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormEdicaoSchema>({
     resolver: zodResolver(formEdicaoSchema),
+    mode: 'onChange',
     defaultValues: {
       inicio: "",
       final: "",
@@ -345,7 +350,7 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
 
       <div className="col-12 mb-1">
         <label className="form-label form-title">
-          Data e horário de início e fim do evento
+          Data de início e fim do evento
           <span className="text-danger ms-1 form-title">*</span>
         </label>
         <div className="d-flex flex-row justify-content-start gap-2 ">
@@ -570,7 +575,9 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
               placeholder="ex.: 20 minutos"
               {...register("duracao", { valueAsNumber: true })}
             />
-            <p className="text-danger error-message"></p>
+            <p className="text-danger error-message">
+              {errors.duracao?.message}
+            </p>
           </div>
         </div>
       </div>
@@ -628,7 +635,7 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
         <button
           type="submit"
           className="btn text-white fs-5 submit-button"
-          disabled={!Edicao?.isActive}
+          disabled={!Edicao?.isActive || !isValid}
         >
           {confirmButton.label}
         </button>

--- a/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
+++ b/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
@@ -103,14 +103,17 @@ const formEdicaoSchema = z.object({
     })
     .nonnegative({
       message: "O número de sessões não pode ser negativo!",
-    }),
+    })
+    .gt(0, { message: "O número de sessões deve ser maior que 0!" }),
+
   duracao: z
     .number({
       invalid_type_error: "Informar a duração é obrigatório!",
     })
     .nonnegative({
       message: "A duração não pode ser negativa!",
-    }),
+    })
+    .gt(0, { message: "A duração deve ser maior que 0!" }),
   submissao: z
     .string({ invalid_type_error: "Campo Inválido" })
     .min(1, "O texto para submissão é obrigatório!"),

--- a/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
+++ b/frontend/src/components/Forms/CadastroEdicao/FormEdicao.tsx
@@ -97,16 +97,20 @@ const formEdicaoSchema = z.object({
     )
     .optional(),
 
-  sessoes: z.number({
-    invalid_type_error: "O número de sessões é obrigatório!",
-  }).nonnegative({
-    message: "O número de sessões não pode ser negativo!"
-  }),
-  duracao: z.number({
-    invalid_type_error: "Informar a duração é obrigatório!",
-  }).nonnegative({
-    message: "A duração não pode ser negativa!"
-  }),
+  sessoes: z
+    .number({
+      invalid_type_error: "O número de sessões é obrigatório!",
+    })
+    .nonnegative({
+      message: "O número de sessões não pode ser negativo!",
+    }),
+  duracao: z
+    .number({
+      invalid_type_error: "Informar a duração é obrigatório!",
+    })
+    .nonnegative({
+      message: "A duração não pode ser negativa!",
+    }),
   submissao: z
     .string({ invalid_type_error: "Campo Inválido" })
     .min(1, "O texto para submissão é obrigatório!"),
@@ -140,7 +144,7 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
   const [avaliadoresOptions, setAvaliadoresOptions] = useState<OptionType[]>(
     []
   );
-  const [comissaoOptions, setComissaoOptions] = useState<OptionType[]>([])
+  const [comissaoOptions, setComissaoOptions] = useState<OptionType[]>([]);
   const router = useRouter();
   const { confirmButton } = ModalSessaoMock;
   registerLocale("pt-BR", ptBR);
@@ -153,7 +157,7 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
     formState: { errors, isValid },
   } = useForm<FormEdicaoSchema>({
     resolver: zodResolver(formEdicaoSchema),
-    mode: 'onChange',
+    mode: "onChange",
     defaultValues: {
       inicio: "",
       final: "",
@@ -301,7 +305,7 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
         value: v.id ?? "",
         label: v.name ?? "",
       }));
-      setComissaoOptions(users)
+      setComissaoOptions(users);
     }
   }, [admins]);
 
@@ -361,13 +365,9 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
               <DatePicker
                 id="ed-inicio-data"
                 onChange={(date) =>
-                  field.onChange(
-                    dayjs(date).toISOString() || null
-                  )
+                  field.onChange(dayjs(date).toISOString() || null)
                 }
-                selected={
-                  field.value ? dayjs(field.value).toDate() : null
-                }
+                selected={field.value ? dayjs(field.value).toDate() : null}
                 showIcon
                 className="form-control datepicker"
                 dateFormat="dd/MM/yyyy"
@@ -375,7 +375,6 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
                 minDate={startOfYear(new Date())}
                 maxDate={endOfYear(new Date())}
                 placeholderText="(ex.: 22/10/2024)"
-                isClearable
                 toggleCalendarOnIconClick
               />
             )}
@@ -404,7 +403,6 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
                 minDate={startOfYear(new Date())}
                 maxDate={endOfYear(new Date())}
                 placeholderText="(ex.: 22/10/2024)"
-                isClearable
                 toggleCalendarOnIconClick
               />
             )}
@@ -612,7 +610,12 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
                   id="ed-deadline-data"
                   showIcon
                   onChange={(date) =>
-                    field.onChange(date?.toISOString() || null)
+                    field.onChange(
+                      dayjs(date)
+                        .set("hour", 23)
+                        .set("minute", 59)
+                        .toISOString() || null
+                    )
                   }
                   selected={field.value ? new Date(field.value) : null}
                   placeholderText="(ex.: 22/10/2024)"
@@ -621,7 +624,6 @@ export function FormEdicao({ edicaoData }: Readonly<FormEdicao>) {
                   locale="pt-BR"
                   minDate={startOfYear(new Date())}
                   maxDate={endOfYear(new Date())}
-                  isClearable
                   toggleCalendarOnIconClick
                 />
               )}

--- a/frontend/src/context/edicao.tsx
+++ b/frontend/src/context/edicao.tsx
@@ -110,6 +110,7 @@ export const EdicaoProvider = ({ children }: EdicaoProps) => {
     try {
       const response = await edicaoApi.createEdicao(body);
       setEdicao(response);
+      setEventEditionIdStorage(response.id);
       showAlert({
         icon: "success",
         title: "Edição cadastrada com sucesso!",
@@ -193,6 +194,7 @@ export const EdicaoProvider = ({ children }: EdicaoProps) => {
     try {
       await edicaoApi.deleteEdicaoById(idEdicao);
       clearEdicao();
+      localStorage.removeItem("edicaoAtiva");
       showAlert({
         icon: "success",
         title: "Edição removida com sucesso!",


### PR DESCRIPTION
Foram adicionadas algumas validações na tela de Cadastro de Edições: 
- Não é possível cadastrar números de sessões negativos
- Não é possível cadastrar duração da apresentação negativa 
- Corrigido o envio do horário da data de submissão. Antes estava enviando como 3:00, alterei para 23:59.
- Retirei a parte de horário tanto da data de início quanto a do final, não estava sendo tratado no input e nem no envio.
- Adicionei uma condicional ao botão, ele só é exibido quando os dados do formulário é válido.